### PR TITLE
Add support for pixi build and bump version to 0.0.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ build*/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #cmake-build-*
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 cmake_minimum_required(VERSION 3.22.1)
 project(ironcub-models
-  VERSION 0.0.1
+  VERSION 0.0.2
   LANGUAGES NONE)
 set(BUILD_PREFIX "iRonCub-Mk3")
 include(GNUInstallDirs)

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,256 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ergocub-models-0.7.10-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_5.conda
+      - conda: .
+        subdir: linux-64
+      linux-aarch64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ergocub-models-0.7.9-h8af1aa0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.1.0-he277a41_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.1.0-he277a41_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.1.0-h3f4de04_5.conda
+      - conda: .
+        subdir: linux-aarch64
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ergocub-models-0.7.10-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.0-hf598326_1.conda
+      - conda: .
+        subdir: osx-arm64
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ergocub-models-0.7.10-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
+      - conda: .
+        build: h9352c13_0
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  build_number: 16
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  build_number: 16
+  sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
+  md5: 6168d71addc746e8f2b8d57dfd2edcea
+  depends:
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23712
+  timestamp: 1650670790230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ergocub-models-0.7.10-ha770c72_0.conda
+  sha256: 78949a35ee0193f6e32004cdb837593689ac7b854e3b20992998e979e20bbbee
+  md5: 2f80d11854e6635dae44054e754b3050
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11264105
+  timestamp: 1757395146718
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ergocub-models-0.7.9-h8af1aa0_2.conda
+  sha256: 75a5e9251cb4b04d3e1d4b7f230322b481575dd0c041857c7c9955ec563b3832
+  md5: cd153c21e2327d5f537241f048ae0d74
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16601101
+  timestamp: 1756797172169
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ergocub-models-0.7.10-hce30654_0.conda
+  sha256: 8d44d008061c943b4fe409bd25ab4c1f2d6940f32fd8fbcb956c6abcceaaee31
+  md5: bb9a137a5b4ba8caea10ccb14721f3a8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11192797
+  timestamp: 1757395601814
+- conda: https://conda.anaconda.org/conda-forge/win-64/ergocub-models-0.7.10-h57928b3_0.conda
+  sha256: 7fe47cdb390813a8db25a6ae9dbf42c7535d54d39a7d823794a91b40a36245d9
+  md5: cb8ce18fb639eef6afbe035e444f40e8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 11203160
+  timestamp: 1757395193461
+- conda: .
+  name: ironcub-models
+  version: 0.0.2
+  build: h9352c13_0
+  subdir: win-64
+  depends:
+  - ergocub-models
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - ucrt >=10.0.20348.0
+  input:
+    hash: 684240eae1ed55699b5e36507a148c06bf60b3929df30d51b1c4be720e20f3c7
+    globs: []
+- conda: .
+  name: ironcub-models
+  version: 0.0.2
+  build: hbf21a9e_0
+  subdir: linux-64
+  depends:
+  - ergocub-models
+  - libstdcxx >=15
+  - libgcc >=15
+  input:
+    hash: 684240eae1ed55699b5e36507a148c06bf60b3929df30d51b1c4be720e20f3c7
+    globs: []
+- conda: .
+  name: ironcub-models
+  version: 0.0.2
+  build: hbf21a9e_0
+  subdir: linux-aarch64
+  depends:
+  - ergocub-models
+  - libstdcxx >=15
+  - libgcc >=15
+  input:
+    hash: 684240eae1ed55699b5e36507a148c06bf60b3929df30d51b1c4be720e20f3c7
+    globs: []
+- conda: .
+  name: ironcub-models
+  version: 0.0.2
+  build: hbf21a9e_0
+  subdir: osx-arm64
+  depends:
+  - ergocub-models
+  - libcxx >=21
+  input:
+    hash: 684240eae1ed55699b5e36507a148c06bf60b3929df30d51b1c4be720e20f3c7
+    globs: []
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.0-hf598326_1.conda
+  sha256: 58427116dc1b58b13b48163808daa46aacccc2c79d40000f8a3582938876fed7
+  md5: 0fb2c0c9b1c1259bc7db75c1342b1d99
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 568692
+  timestamp: 1756698505599
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_5.conda
+  sha256: 0caed73aac3966bfbf5710e06c728a24c6c138605121a3dacb2e03440e8baa6a
+  md5: 264fbfba7fb20acf3b29cde153e345ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 15.1.0 h767d61c_5
+  - libgcc-ng ==15.1.0=*_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 824191
+  timestamp: 1757042543820
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.1.0-he277a41_5.conda
+  sha256: 99d44310fa159590766d77fdd2d90d26a13406f703591f64f4fb78ec7cfe142e
+  md5: 1c5fcbb9e0d333dc1d9206b0847e2d93
+  depends:
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.1.0=*_5
+  - libgomp 15.1.0 he277a41_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 511668
+  timestamp: 1757043002003
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_5.conda
+  sha256: 125051d51a8c04694d0830f6343af78b556dd88cc249dfec5a97703ebfb1832d
+  md5: dcd5ff1940cd38f6df777cac86819d60
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 447215
+  timestamp: 1757042483384
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.1.0-he277a41_5.conda
+  sha256: 3573b6f0b9037ee69c1fb39a6614c05f919191149196f2b33fb2acdf7caece59
+  md5: da1eb826fad1995cb91f385da6efb919
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 450637
+  timestamp: 1757042941171
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_5.conda
+  sha256: 0f5f61cab229b6043541c13538d75ce11bd96fb2db76f94ecf81997b1fde6408
+  md5: 4e02a49aaa9d5190cb630fa43528fbe6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.1.0 h767d61c_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3896432
+  timestamp: 1757042571458
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-15.1.0-h3f4de04_5.conda
+  sha256: 012b552fdb3fc4f703341b4c6d56313951f3fa8e817a7e7ecaef99d51920faad
+  md5: 06758dc7550f212f095936e35255f32e
+  depends:
+  - libgcc 15.1.0 he277a41_5
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3827611
+  timestamp: 1757043023868
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
+  md5: 71b24316859acd00bdb8b38f5e2ce328
+  constrains:
+  - vc14_runtime >=14.29.30037
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 694692
+  timestamp: 1756385147981
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_31.conda
+  sha256: cb357591d069a1e6cb74199a8a43a7e3611f72a6caed9faa49dbb3d7a0a98e0b
+  md5: 28f4ca1e0337d0f27afb8602663c5723
+  depends:
+  - vc14_runtime >=14.44.35208
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18249
+  timestamp: 1753739241465
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_31.conda
+  sha256: af4b4b354b87a9a8d05b8064ff1ea0b47083274f7c30b4eb96bc2312c9b5f08f
+  md5: 603e41da40a765fd47995faa021da946
+  depends:
+  - ucrt >=10.0.20348.0
+  - vcomp14 14.44.35208 h818238b_31
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_31
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 682424
+  timestamp: 1753739239305
+- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_31.conda
+  sha256: 67b317b64f47635415776718d25170a9a6f9a1218c0f5a6202bfd687e07b6ea4
+  md5: a6b1d5c1fc3cb89f88f7179ee6a9afe3
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_31
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 113963
+  timestamp: 1753739198723

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,30 @@
+[workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "win-64", "osx-arm64"]
+preview = ["pixi-build"]
+
+
+
+[package]
+authors = ["Davide Gorbani <davide.gorbani@iit.it>"]
+name = "ironcub-models"
+version = "0.0.2"
+
+[tasks]
+
+[dependencies]
+ironcub-models = { path = "." }
+
+[package.build.backend]
+channels = [
+  "https://prefix.dev/pixi-build-backends",
+  "https://prefix.dev/conda-forge",
+]
+name = "pixi-build-cmake"
+version = "*"
+
+[package.run-dependencies]
+# This is just a workaround: we should add the conda prefix to ROS_PACKAGE_PATH and AMENT_PREFIX_PATH, 
+# but this is not supported at the moment by pixi build, so we just add a dependency on a package
+# that set those variables
+ergocub-models = "*"


### PR DESCRIPTION
This PR adds support for pixi-build in this repo, as documented in https://prefix.dev/blog/pixi-build-for-cmake-projects. The main advantage this provides is that it would be possible to add a dependency on this package when compiling from source, to permit to depend on an unrelesed version of the repo.

One annoyance is that now the version is duplicated between pixi.toml and CMakeLists.txt, so we need to remember to bump both before a release.